### PR TITLE
Added pick block functionality fixes #25

### DIFF
--- a/LB-source/slimevoid/littleblocks/blocks/BlockLittleChunk.java
+++ b/LB-source/slimevoid/littleblocks/blocks/BlockLittleChunk.java
@@ -810,7 +810,7 @@ public class BlockLittleChunk extends BlockContainer {
 		if (tileentity != null && tileentity instanceof TileEntityLittleChunk) {
     	int xx = (par2 << 3) + xSelected, yy = (par3 << 3) + ySelected, zz = (par4 << 3) + zSelected;
 		World littleWorld = (World) ((TileEntityLittleChunk)tileentity).getLittleWorld();
-		damage =this.damageDropped(littleWorld.getBlockMetadata(par2, par3, par4));;
+		damage =this.damageDropped(littleWorld.getBlockMetadata(xx, yy, zz));;
 		}
         return damage;
     }


### PR DESCRIPTION
will return the border block ID and damage if no LB is in chunk and if the user is highlighting that block

fixes issue #25 
