### PR TITLE
Compatibility 2.0.1.1

### DIFF
--- a/LB-source/slimevoid/littleblocks/core/LBCore.java
+++ b/LB-source/slimevoid/littleblocks/core/LBCore.java
@@ -63,8 +63,8 @@ public class LBCore {
 											256,
 											1,
 											false);
-		GameRegistry.registerTileEntity(TileEntityLittleChunk.class,
-										BlockLib.LITTLEBLOCKS);
+		GameRegistry.registerTileEntity(TileEntityLittleChunk.class, BlockLib.LITTLEBLOCKS);
+		GameRegistry.registerTileEntity(TileEntityLittleChunk.class, BlockLib.LITTLEBLOCKS_COMPATIBILITY);
 		BlockUtil.registerPlacementInfo();
 	}
 }

--- a/LB-source/slimevoid/littleblocks/core/lib/BlockLib.java
+++ b/LB-source/slimevoid/littleblocks/core/lib/BlockLib.java
@@ -5,6 +5,8 @@ public class BlockLib {
 	private static final String	BLOCK_PREFIX	= "lb.";
 
 	public static final String	LITTLEBLOCKS	= "littleblocks";
+	
+	public static final String	LITTLEBLOCKS_COMPATIBILITY	= "littleBlocks";
 
 	public static final String	LITTLECHUNK		= BLOCK_PREFIX + LITTLEBLOCKS;
 }


### PR DESCRIPTION
Hello,

In the 2.0.1.1 the tileEntity had a uppercase.
I add a compatibility key on tileEntity.

Good day.
